### PR TITLE
Reorder `brew_tap_list`

### DIFF
--- a/mac
+++ b/mac
@@ -311,11 +311,11 @@ brew_migrate_or_add_tap() {
   true
 }
 
-TAPS=$(brew_tap_list)
-
 brew_tap_list() {
   brew tap 2> /dev/null || true
 }
+
+TAPS=$(brew_tap_list)
 
 is_brew_tap_installed() {
   echo ${TAPS} | grep -q "\b$1"

--- a/mac-components/homebrew
+++ b/mac-components/homebrew
@@ -77,11 +77,11 @@ brew_migrate_or_add_tap() {
   true
 }
 
-TAPS=$(brew_tap_list)
-
 brew_tap_list() {
   brew tap 2> /dev/null || true
 }
+
+TAPS=$(brew_tap_list)
 
 is_brew_tap_installed() {
   echo ${TAPS} | grep -q "\b$1"


### PR DESCRIPTION
- fixes `mac: line 314: brew_tap_list: command not found`
